### PR TITLE
Add cluster_group identification to AWS and GCP instance type info

### DIFF
--- a/citc/aws.py
+++ b/citc/aws.py
@@ -102,6 +102,7 @@ def get_types_info(client: EC2Client) -> Dict[str, NodeTypeInfo]:
             ),
             "threads_per_core": d["VCpuInfo"].get("DefaultThreadsPerCore", 1),
             "arch": d["ProcessorInfo"]["SupportedArchitectures"][0],
+            "cluster_group": 'cluster' in d["PlacementGroupInfo"]["SupportedStrategies"]
         }
         for s, d in instances.items()
     }

--- a/citc/google.py
+++ b/citc/google.py
@@ -106,6 +106,7 @@ def get_types_info(client, nodespace):
             "memory": int(math.pow(mt["memoryMb"], 0.7) * 0.9 + 500),
             "cores_per_socket": mt["guestCpus"],
             "threads_per_core": "1",
+            "cluster_group": mt["name"].startswith("c2-") # only C2 currently support compact placement groups
         }
         for mt in machine_types
     }


### PR DESCRIPTION
Not all AWS and GCP instance types support compact/cluster placement policies.   Include an indication in the node type information whether HPC placement groups are supported.