### PR TITLE
Make CSP selecteable by extras

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,17 +8,17 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
         run: pip install poetry
       - name: Setup package
-        run: poetry install
+        run: poetry install --all-extras
       - name: Run flake8
         run: poetry run flake8
       - name: Run mypy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,9 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: "3.x"
       - name: Install Poetry
@@ -34,7 +34,7 @@ jobs:
           draft: false
           prerelease: false
       - name: Upload packages
-        uses: actions/upload-release-asset@v1.0.1  # Update to v1 when https://github.com/actions/upload-release-asset/issues/23
+        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/citc/list_nodes.py
+++ b/citc/list_nodes.py
@@ -13,7 +13,7 @@ def create_table(
     for slurm_node in slurm_nodes:
         matches = [node for node in cloud_nodes if node.name == slurm_node.name]
         if len(matches) == 1:
-            cloud_state = matches[0].state  # type: Optional[cloud.NodeState]
+            cloud_state: Optional[cloud.NodeState] = matches[0].state
         else:
             cloud_state = None
         table.append(

--- a/citc/utils.py
+++ b/citc/utils.py
@@ -2,7 +2,7 @@ from typing import Dict, List
 
 import yaml
 
-from . import aws, oracle, cloud, google
+from . import cloud
 
 
 def load_yaml(filename: str) -> dict:
@@ -23,12 +23,18 @@ def get_cloud_nodes() -> List[cloud.CloudNode]:
 
     csp = nodespace["csp"]
     if csp == "aws":
+        from . import aws
+
         ec2 = aws.ec2_client(nodespace)
         cloud_nodes = aws.AwsNode.all(ec2, nodespace)
     elif csp == "google":
+        from . import google
+
         client = google.client(nodespace)
         cloud_nodes = google.GoogleNode.all(client, nodespace)
     elif csp == "oracle":
+        from . import oracle
+
         config = oracle.get_config()
         cloud_nodes = oracle.OracleNode.all(config, nodespace)
     elif csp == "azure":
@@ -48,9 +54,13 @@ def get_types_info() -> Dict[str, cloud.NodeTypeInfo]:
 
     csp = nodespace["csp"]
     if csp == "aws":
+        from . import aws
+
         ec2 = aws.ec2_client(nodespace)
         return aws.get_types_info(ec2)
     elif csp == "google":
+        from . import google
+
         client = google.client(nodespace)
         return google.get_types_info(client, nodespace)
     elif csp == "oracle":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,14 +6,14 @@ authors = ["Matt Williams <matt@milliams.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.8.1"
 PyYaml = "^6.0"
-tabulate = "^0.8"
-boto3 = {version = "^1.20", optional = true }
-oci = {version = "^2.54.0", optional = true }
-google-api-python-client = {version = "^2.35.0", optional = true }
-google-auth-oauthlib = {version = "^0.4.6", optional = true }
-boto3-stubs = {version = "^1.20", extras = ["ec2", "route53"], optional = true }
+tabulate = "^0.9"
+boto3 = {version = "^1.28", optional = true }
+oci = {version = "^2.105.0", optional = true }
+google-api-python-client = {version = "^2.92.0", optional = true }
+google-auth-oauthlib = {version = "^0.8", optional = true }
+boto3-stubs = {version = "^1.28", extras = ["ec2", "route53"], optional = true }
 
 [tool.poetry.extras]
 aws = ["boto3", "boto3-stubs"]
@@ -22,16 +22,16 @@ google = ["google-api-python-client", "google-auth-oauthlib"]
 oracle = ["oci"]
 
 [tool.poetry.dev-dependencies]
-pytest = "^6.2"
-pytest-mock = "^3.6"
-pyfakefs = "^4.5"
-black = {version = "^21.12b0", allow-prereleases = true}
-mypy = "^0.931"
+pytest = "^7.0"
+pytest-mock = "^3.11"
+pyfakefs = "^5.2"
+black = {version = "^23.3"}
+mypy = "^1.4.1"
 types_PyYAML = "^6.0"
-types_tabulate = "^0.8"
-flake8 = "^4.0"
-moto = "^2.0"
-coverage = "^6.2"
+types_tabulate = "^0.9"
+flake8 = "^6.0"
+moto = "^4.0"
+coverage = "^7.0"
 mebula = {version = "^0.2.9", allow-prereleases = true, extras = ["azure", "google", "oracle"]}
 
 [tool.poetry.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,19 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-boto3 = "^1.20"
 PyYaml = "^6.0"
-oci = "^2.54.0"
 tabulate = "^0.8"
-google-api-python-client = "^2.35.0"
-google-auth-oauthlib = "^0.4.6"
-boto3-stubs = {version = "^1.20", extras = ["ec2", "route53"]}
+boto3 = {version = "^1.20", optional = true }
+oci = {version = "^2.54.0", optional = true }
+google-api-python-client = {version = "^2.35.0", optional = true }
+google-auth-oauthlib = {version = "^0.4.6", optional = true }
+boto3-stubs = {version = "^1.20", extras = ["ec2", "route53"], optional = true }
+
+[tool.poetry.extras]
+aws = ["boto3", "boto3-stubs"]
+azure = []
+google = ["google-api-python-client", "google-auth-oauthlib"]
+oracle = ["oci"]
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2"


### PR DESCRIPTION
Currently, regardless of which cloud system you are on, all the Python dependencies for all the providers will be installed. This takes a long time and slows down deployment. This PR will allow you to select just the cloud service provider you want.